### PR TITLE
update lexicon version due to dnsmadeeasy fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Adrien Ferrand <ferrand.ad@gmail.com>"
 ENV PATH /scripts:$PATH
 
 # Versioning
-ENV LEXICON_VERSION 2.1.11
+ENV LEXICON_VERSION 2.1.14
 ENV CERTBOT_VERSION 0.19.0
 
 # Let's Encrypt configuration

--- a/README.md
+++ b/README.md
@@ -258,11 +258,11 @@ You will need to wipe content of `/etc/letsencrypt` volume before container re-c
 
 ### Auto-export certificates in PFX format
 
-Some services need the SSL key and certificate stored together in PFX format (also known as PKCS#12) whose extension is .pfx (or .p12). For this purpose one can set the container environment variable `EXPORT_PFX (default: false)` to `true`: in this case, the container will ensure that every certificate handled by Certbot is exported in PFX format during certificate creation, renewal or container start/restart.
+Some services need the SSL key and certificate stored together in PFX format (also known as PKCS#12) whose extension is .pfx (or .p12). For this purpose one can set the container environment variable `PFX_EXPORT (default: false)` to `true`: in this case, the container will ensure that every certificate handled by Certbot is exported in PFX format during certificate creation, renewal or container start/restart.
 
 The PFX certificate for a given primary domain is located in the container on `/etc/letsencrypt/[DOMAIN]/cert.pks`: it contains the key, certificate and all intermediate certificates.
 
-By default, the PFX certificates are not protected by a passphrase. You can define one using the environment variable `EXPORT_PFX_PASSPHRASE`.
+By default, the PFX certificates are not protected by a passphrase. You can define one using the environment variable `PFX_EXPORT_PASSPHRASE`.
 
 ### Sleep time
 


### PR DESCRIPTION
Signed-off-by: Robbie Page <rob@rorpage.com>

Lexicon updated a few versions today and one of the fixes included a change in how dates are used for the DNS Made Easy auth calls (https://github.com/AnalogJ/lexicon/releases).

Thanks so much for this repo!