### PR TITLE
Add option to restart docker services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ ENV CERTS_FILES_MODE 0640
 ENV CERTS_USER_OWNER root
 ENV CERTS_GROUP_OWNER root
 
+# Container restart configuration
+ENV DOCKER_SWARM false
+
 # Install dependencies, certbot, lexicon, prepare for first start and clean
 RUN apk --no-cache --update add rsyslog git openssl libffi supervisor docker \
 && apk --no-cache --update --virtual build-dependencies add libffi-dev openssl-dev python-dev build-base \

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ docker run \
 
 If the certificate `smtp.example.com` is renewed, the container named `smtp` will be restarted. Renewal of `auth.example.com` will not restart anything.
 
+### Docker Swarm Services
+Specifying `DOCKER_SWARM=true` as an environment value will restart containers by their service name instead.
+
 ### Call a reload command on containers when a certificate is renewed
 
 Restarting a container when a certificate is renewed is sufficient for all cases. However one drawback is that the target processes will stop during a little time, and consequently the services provided are not continuous. This may be ok for non critical services, but problematic for things like authentication services or database servers.

--- a/files/autorestart-containers.sh
+++ b/files/autorestart-containers.sh
@@ -2,6 +2,7 @@
 
 domain=$1
 containers=$2
+new_certificate=$3
 
 if [ ! -S /var/run/docker.sock ]; then
     echo "ERROR: /var/run/docker.sock socket is missing."
@@ -13,21 +14,30 @@ if [ ! -d /etc/letsencrypt/archive/$domain ]; then
     exit 1
 fi
 
+restart() {
+    IFS=','; for container in $containers; do
+        if [ "$DOCKER_SWARM" == true ]; then
+            docker service update --detach=false --force $container
+        else
+            docker restart $container
+        fi
+    done; unset IFS
+}
+
 # Load hash of the certificate
 current_hash=`md5sum /etc/letsencrypt/live/$domain/cert.pem | awk '{ print $1 }'`
 while true; do
     new_hash=`md5sum /etc/letsencrypt/live/$domain/cert.pem | awk '{ print $1 }'`
 
+    if [ "$new_certificate" == true ]; then
+        echo ">>> Restarting dockers $containers because certificate for $domain has been created."
+        restart
+        new_certificate=false
+    fi
+
     if [ "$current_hash" != "$new_hash" ]; then
         echo ">>> Restarting dockers $containers because certificate for $domain has been modified."
-        IFS=','; for container in $containers; do
-          if [ "$DOCKER_SWARM" == true ]; then
-            docker service update --detach=false --force $container
-          else
-            docker restart $container
-          fi
-        done; unset IFS
-
+        restart
         # Keep new hash version
         current_hash="$new_hash"
     fi

--- a/files/autorestart-containers.sh
+++ b/files/autorestart-containers.sh
@@ -21,7 +21,11 @@ while true; do
     if [ "$current_hash" != "$new_hash" ]; then
         echo ">>> Restarting dockers $containers because certificate for $domain has been modified."
         IFS=','; for container in $containers; do
+          if [ "$DOCKER_SWARM" = true ]; then
+            docker service update --detach=false --force $container
+          else
             docker restart $container
+          fi
         done; unset IFS
 
         # Keep new hash version

--- a/files/autorestart-containers.sh
+++ b/files/autorestart-containers.sh
@@ -21,7 +21,7 @@ while true; do
     if [ "$current_hash" != "$new_hash" ]; then
         echo ">>> Restarting dockers $containers because certificate for $domain has been modified."
         IFS=','; for container in $containers; do
-          if [ "$DOCKER_SWARM" = true ]; then
+          if [ "$DOCKER_SWARM" == true ]; then
             docker service update --detach=false --force $container
           else
             docker restart $container

--- a/files/watch-domains.sh
+++ b/files/watch-domains.sh
@@ -56,6 +56,11 @@ while true; do
                 $domains_cmd
 
             if [ "$autorestart_config" != "" ]; then
+		if [ "$AUTO_RESTART_NEW" == true ]; then
+		  echo ">>> New certificate for main domain $main_domain: containers $autorestart_config will be restarted."
+		  /scripts/autorestart-containers.sh $main_domain $autorestart_config
+		fi
+		
                 echo ">>> Watching certificate for main domain $main_domain: containers $autorestart_config autorestarted when certificate is changed."
                 echo "[program:${main_domain}_autorestart-containers]" >> /etc/supervisord.d/${main_domain}_autorestart-containers
                 echo "command = /scripts/autorestart-containers.sh $main_domain $autorestart_config" >> /etc/supervisord.d/${main_domain}_autorestart-containers

--- a/files/watch-domains.sh
+++ b/files/watch-domains.sh
@@ -56,14 +56,13 @@ while true; do
                 $domains_cmd
 
             if [ "$autorestart_config" != "" ]; then
-		if [ "$AUTO_RESTART_NEW" == true ]; then
-		  echo ">>> New certificate for main domain $main_domain: containers $autorestart_config will be restarted."
-		  /scripts/autorestart-containers.sh $main_domain $autorestart_config
-		fi
-		
                 echo ">>> Watching certificate for main domain $main_domain: containers $autorestart_config autorestarted when certificate is changed."
                 echo "[program:${main_domain}_autorestart-containers]" >> /etc/supervisord.d/${main_domain}_autorestart-containers
-                echo "command = /scripts/autorestart-containers.sh $main_domain $autorestart_config" >> /etc/supervisord.d/${main_domain}_autorestart-containers
+		if [ "$AUTO_RESTART_NEW" == true ]; then
+                  echo "command = /scripts/autorestart-containers.sh $main_domain $autorestart_config true" >> /etc/supervisord.d/${main_domain}_autorestart-containers
+		else
+		  echo "command = /scripts/autorestart-containers.sh $main_domain $autorestart_config false" >> /etc/supervisord.d/${main_domain}_autorestart-containers
+		fi
                 echo "redirect_stderr = true" >> /etc/supervisord.d/${main_domain}_autorestart-containers
                 echo "stdout_logfile = /dev/stdout" >> /etc/supervisord.d/${main_domain}_autorestart-containers
                 echo "stdout_logfile_maxbytes = 0" >> /etc/supervisord.d/${main_domain}_autorestart-containers


### PR DESCRIPTION
This should allow the restart of services deployed inside a docker swarm.
A use case would be a nginx service deployed globally in a cluster while having `docker-letsencrypt-dns` and `docker-gen` run with `--replicas 1`. An update to a certificate could then trigger the restart of `docker-gen` by its service name in the cluster.