### PR TITLE
Verify DNS propagation before requesting certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV LEXICON_VERSION 3.2.7
 ENV CERTBOT_VERSION 0.35.1
 
 # Install dependencies, certbot, lexicon, prepare for first start and clean
-RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool tzdata bash \
+RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool tzdata bash bind-tools \
  && apk --no-cache --update --virtual build-dependencies add libffi-dev libxml2-dev libxslt-dev openssl-dev build-base linux-headers \
  && pip install --no-cache-dir "certbot==$CERTBOT_VERSION" \
  && pip install --no-cache-dir "dns-lexicon[full]==$LEXICON_VERSION" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ ENV LETSENCRYPT_STAGING=false \
 # Lexicon configuration
 ENV LEXICON_OPTIONS="" \
     LEXICON_PROVIDER=cloudflare \
-    LEXICON_PROVIDER_OPTIONS=""
+    LEXICON_PROVIDER_OPTIONS="" \
+    LEXICON_SLEEP_TIME=30 \
+    LEXICON_SLEEP_MAX_RETRY=3
 
 # Container specific configuration
 ENV TZ=UTC \

--- a/files/authenticator.sh
+++ b/files/authenticator.sh
@@ -10,7 +10,13 @@ else
 	NS=$(dig +short NS $CERTBOT_DOMAIN @$LEXICON_NAMESERVER)
 fi
 
+tries=0
 while : ; do
+  tries=$((tries + 1))
+  if [ $tries -ge $LEXICON_SLEEP_MAX_RETRY ]; then
+    echo "The challenge was not propagated after the maximum tries of $LEXICON_SLEEP_MAX_RETRY"
+    exit 1
+  fi
   for ns in $NS
   do
     result=$(dig +short TXT $CERTBOT_DOMAIN @$ns)

--- a/files/authenticator.sh
+++ b/files/authenticator.sh
@@ -16,8 +16,8 @@ while : ; do
 	set -e
 
     if [ $hasEntry -ne 0 ]; then
-      echo "NS $ns did not have expected value, trying again in ${LEXICON_SLEEP_TIME:-30} seconds"
-      sleep ${LEXICON_SLEEP_TIME:-30}
+      echo "NS $ns did not have expected value, trying again in $LEXICON_SLEEP_TIME seconds"
+      sleep $LEXICON_SLEEP_TIME
       continue 2
     fi
   done

--- a/files/authenticator.sh
+++ b/files/authenticator.sh
@@ -4,7 +4,11 @@ set -e
 cd /etc/letsencrypt
 lexicon $LEXICON_OPTIONS $LEXICON_PROVIDER $LEXICON_PROVIDER_OPTIONS create $CERTBOT_DOMAIN TXT --name="_acme-challenge.$CERTBOT_DOMAIN." --content="$CERTBOT_VALIDATION"
 
-NS=$(dig +short NS $CERTBOT_DOMAIN)
+if [ -z "$LEXICON_NAMESERVER" ]; then
+	NS=$(dig +short NS $CERTBOT_DOMAIN)
+else
+	NS=$(dig +short NS $CERTBOT_DOMAIN @$LEXICON_NAMESERVER)
+fi
 
 while : ; do
   for ns in $NS

--- a/files/authenticator.sh
+++ b/files/authenticator.sh
@@ -4,4 +4,22 @@ set -e
 cd /etc/letsencrypt
 lexicon $LEXICON_OPTIONS $LEXICON_PROVIDER $LEXICON_PROVIDER_OPTIONS create $CERTBOT_DOMAIN TXT --name="_acme-challenge.$CERTBOT_DOMAIN." --content="$CERTBOT_VALIDATION"
 
-sleep ${LEXICON_SLEEP_TIME:-30}
+NS=$(dig +short NS $CERTBOT_DOMAIN)
+
+while : ; do
+  for ns in $NS
+  do
+    result=$(dig +short TXT $CERTBOT_DOMAIN @$ns)
+	set +e
+    dig +short TXT _acme-challenge.$CERTBOT_DOMAIN @$ns | grep -w "\"$CERTBOT_VALIDATION\"" > /dev/null 2>&1
+    hasEntry=$?
+	set -e
+
+    if [ $hasEntry -ne 0 ]; then
+      echo "NS $ns did not have expected value, trying again in ${LEXICON_SLEEP_TIME:-30} seconds"
+      sleep ${LEXICON_SLEEP_TIME:-30}
+      continue 2
+    fi
+  done
+  break
+done


### PR DESCRIPTION
Hi,
Some DNS providers can be quite slow to propagate changes (such as Gandi).
This PR adds a check in authenticator.sh that checks the domain's every name servers and verifies that the changes are propagated.