### PR TITLE
Run a custom deploy hook script defined in DEPLOY_HOOK environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV CERTS_DIRS_MODE 0750
 ENV CERTS_FILES_MODE 0640
 ENV CERTS_USER_OWNER root
 ENV CERTS_GROUP_OWNER root
+ENV DEPLOY_HOOK ""
 
 # Install dependencies, certbot, lexicon, prepare for first start and clean
 RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool \

--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ cd "/etc/nginx/certs"
 for domain in ${RENEWED_DOMAINS}; do
     cp "${RENEWED_LINEAGE}/fullchain.pem" "${domain}.crt"
     cp "${RENEWED_LINEAGE}/privkey.pem" "${domain}.key"
+    chown $CERTS_USER_OWNER:$CERTS_GROUP_OWNER "${domain}.*"
+    chmod $CERTS_FILES_MODE "${domain}.*"
 done
-chown $CERTS_USER_OWNER:$CERTS_GROUP_OWNER "${domain}.*"
-chmod $CERTS_FILES_MODE "${domain}.*"
 ```   
 
 Execute:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 	* [Certificates reconfiguration at runtime](#certificates-reconfiguration-at-runtime)
 	* [Restart containers when a certificate is renewed](#restart-containers-when-a-certificate-is-renewed)
 	* [Call a reload command on containers when a certificate is renewed](#call-a-reload-command-on-containers-when-a-certificate-is-renewed)
+	* [Run a custom deploy hook script](#run-a-custom-deploy-hook-script)
 * [Miscellaneous and testing](#miscellaneous-and-testing)
 	* [Using ACME v1 servers](#using-acme-v1-servers)
 	* [Activate staging ACME servers](#activating-staging-acme-servers)
@@ -295,6 +296,46 @@ web.example.com autocmd-containers=my-apache:apachectl graceful
 If the certificate `web.example.com` is renewed, command `apachectl graceful` will be invoked on container `my-apache`, and the apache2 service will use the new certificate without killing any HTTP session.
 
 _(Limitations on invokable commands) The option `autocmd-container` is intended to call a simple executable file with few potential arguments. It is not made to call some advanced bash script, and would likely fail if you do so. In fact, the command is not executed in a shell on the target, and variables will be resolved against the lets-encrypt container environment. If you want to operate advanced scripting, put an executable script in the target container, and use its path in `autocmd-container` option._
+
+### Run a custom deploy hook script
+
+You can specify a script or a command to execute after a certificate is created or renewed, by specifying `DEPLOY_HOOK` environment variable. This is useful if you want to copy certificates someplace else or need to reorganize file structure.
+
+All standard environment variables will be available in your script, as well as two new variables set by certbot:
+* `RENEWED_LINEAGE` - directory with certificate files (e.g. `/etc/letsencrypt/live/domain`)
+* `RENEWED_DOMAINS` - list of domains for the certificate, separated by space 
+
+Example: copying all new or renewed certificates to a single directory with `domain.crt` and `domain.key` filenames, making it easily usable with nginx:
+
+Create deploy-hook.sh file and make it executable. 
+
+```bash
+#!/bin/sh
+mkdir -p "/etc/nginx/certs"
+cd "/etc/nginx/certs"
+for domain in ${RENEWED_DOMAINS}; do
+    cp "${RENEWED_LINEAGE}/fullchain.pem" "${domain}.crt"
+    cp "${RENEWED_LINEAGE}/privkey.pem" "${domain}.key"
+done
+chown $CERTS_USER_OWNER:$CERTS_GROUP_OWNER "${domain}.*"
+chmod $CERTS_FILES_MODE "${domain}.*"
+```   
+
+Execute:
+```bash
+docker run \
+	--name letsencrypt-dns \
+	--volume /etc/letsencrypt/domains.conf:/etc/letsencrypt/domains.conf \
+	--volume /etc/letsencrypt/deploy-hook.sh:/usr/local/bin/create-nginx-certs \
+	--volume /var/docker-data/letsencrypt:/etc/letsencrypt \
+	--volume /var/docker-data/nginx:/etc/nginx/certs \
+	--env 'LETSENCRYPT_USER_MAIL=admin@example.com' \
+	--env 'LEXICON_PROVIDER=cloudflare' \
+	--env 'LEXICON_CLOUDFLARE_USERNAME=my_cloudflare_email' \
+	--env 'LEXICON_CLOUDFLARE_TOKEN=my_cloudflare_global_api_key' \
+	--env 'DEPLOY_HOOK=create-nginx-certs' \
+	adferrand/letsencrypt-dns
+```
 
 ## Miscellaneous and testing
 

--- a/files/deploy-hook.sh
+++ b/files/deploy-hook.sh
@@ -14,3 +14,7 @@ fi
 find $RENEWED_LINEAGE ${RENEWED_LINEAGE/live/archive} -type d -exec chmod "$CERTS_DIRS_MODE" {} +
 find $RENEWED_LINEAGE ${RENEWED_LINEAGE/live/archive} -type f -exec chmod "$CERTS_FILES_MODE" {} +
 chown -R $CERTS_USER_OWNER:$CERTS_GROUP_OWNER $RENEWED_LINEAGE ${RENEWED_LINEAGE/live/archive}
+
+if [ ! -z "$DEPLOY_HOOK" ]; then
+    sh -c ${DEPLOY_HOOK}
+fi

--- a/files/deploy-hook.sh
+++ b/files/deploy-hook.sh
@@ -16,5 +16,5 @@ find $RENEWED_LINEAGE ${RENEWED_LINEAGE/live/archive} -type f -exec chmod "$CERT
 chown -R $CERTS_USER_OWNER:$CERTS_GROUP_OWNER $RENEWED_LINEAGE ${RENEWED_LINEAGE/live/archive}
 
 if [ ! -z "$DEPLOY_HOOK" ]; then
-    sh -c ${DEPLOY_HOOK}
+    sh -c "${DEPLOY_HOOK}"
 fi


### PR DESCRIPTION
I needed to share generated certificates with nginx, but there were no easy way to do it as nginx expects different directory/file structure. This is a popular need, as can be seen in #16.

Solution recommended in the issue, to put a script in `/etc/letsencrypt/renewal-hooks/deploy` does not help much, because scripts from this directory are executed only on certificate renewal. They are **not** executed on certificate creation.

This pull requests introduces `DEPLOY_HOOK` environment variable allowing to execute a custom deploy hook every time a certificate is created or renewed.

It's best described by a change in README (also included in the commit), so I paste it below for better readability: 

---

### Run a custom deploy hook script

You can specify a script or a command to execute after a certificate is created or renewed, by specifying `DEPLOY_HOOK` environment variable. This is useful if you want to copy certificates someplace else or need to reorganize file structure.

All standard environment variables will be available in your script, as well as two new variables set by certbot:
* `RENEWED_LINEAGE` - directory with certificate files (e.g. `/etc/letsencrypt/live/domain`)
* `RENEWED_DOMAINS` - list of domains for the certificate, separated by space 

Example: copying all new or renewed certificates to a single directory with `domain.crt` and `domain.key` filenames, making it easily usable with nginx:

Create deploy-hook.sh file and make it executable. 

```bash
#!/bin/sh
mkdir -p "/etc/nginx/certs"
cd "/etc/nginx/certs"
for domain in ${RENEWED_DOMAINS}; do
    cp "${RENEWED_LINEAGE}/fullchain.pem" "${domain}.crt"
    cp "${RENEWED_LINEAGE}/privkey.pem" "${domain}.key"
    chown $CERTS_USER_OWNER:$CERTS_GROUP_OWNER "${domain}.*"
    chmod $CERTS_FILES_MODE "${domain}.*"
done
```   

Execute:
```bash
docker run \
	--name letsencrypt-dns \
	--volume /etc/letsencrypt/domains.conf:/etc/letsencrypt/domains.conf \
	--volume /etc/letsencrypt/deploy-hook.sh:/usr/local/bin/create-nginx-certs \
	--volume /var/docker-data/letsencrypt:/etc/letsencrypt \
	--volume /var/docker-data/nginx:/etc/nginx/certs \
	--env 'LETSENCRYPT_USER_MAIL=admin@example.com' \
	--env 'LEXICON_PROVIDER=cloudflare' \
	--env 'LEXICON_CLOUDFLARE_USERNAME=my_cloudflare_email' \
	--env 'LEXICON_CLOUDFLARE_TOKEN=my_cloudflare_global_api_key' \
	--env 'DEPLOY_HOOK=create-nginx-certs' \
	adferrand/letsencrypt-dns
```
