### PR TITLE
Added timezone support and made certificate renewal timing customisable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV CERTS_GROUP_OWNER root
 ENV DEPLOY_HOOK ""
 
 # Install dependencies, certbot, lexicon, prepare for first start and clean
-RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool tzdata \
+RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool tzdata bash \
  && apk --no-cache --update --virtual build-dependencies add libffi-dev libxml2-dev libxslt-dev openssl-dev build-base linux-headers \
  && pip install "certbot==$CERTBOT_VERSION" \
  && pip install "dns-lexicon[full]==$LEXICON_VERSION" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV LEXICON_PROVIDER cloudflare
 ENV LEXICON_PROVIDER_OPTIONS ""
 
 # Container specific configuration
+ENV TZ UTC
+ENV CRON_TIME_STRING "12 01,13 * * *"
 ENV PFX_EXPORT false
 ENV PFX_EXPORT_PASSPHRASE ""
 ENV CERTS_DIRS_MODE 0750
@@ -29,7 +31,7 @@ ENV CERTS_GROUP_OWNER root
 ENV DEPLOY_HOOK ""
 
 # Install dependencies, certbot, lexicon, prepare for first start and clean
-RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool \
+RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool tzdata \
  && apk --no-cache --update --virtual build-dependencies add libffi-dev libxml2-dev libxslt-dev openssl-dev build-base linux-headers \
  && pip install "certbot==$CERTBOT_VERSION" \
  && pip install "dns-lexicon[full]==$LEXICON_VERSION" \
@@ -43,7 +45,6 @@ COPY files/run.sh /scripts/run.sh
 COPY files/watch-domains.sh /scripts/watch-domains.sh
 COPY files/autorestart-containers.sh /scripts/autorestart-containers.sh
 COPY files/autocmd-containers.sh /scripts/autocmd-containers.sh
-COPY files/crontab /etc/crontab
 COPY files/circus.ini /etc/circus.ini
 COPY files/letsencrypt-dns.ini /etc/circus.d/letsencrypt-dns.ini
 COPY files/authenticator.sh /var/lib/letsencrypt/hooks/authenticator.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 	* [Run a custom deploy hook script](#run-a-custom-deploy-hook-script)
 * [Miscellaneous and testing](#miscellaneous-and-testing)
 	* [Using ACME v1 servers](#using-acme-v1-servers)
+	* [Specifying the renewal schedule](#specifying-the-renewal-schedule)
 	* [Activate staging ACME servers](#activating-staging-acme-servers)
 	* [Auto-export certificates in PFX format](#auto-export-certificates-in-pfx-format)
     * [Sleep time](#sleep-time)

--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ Starting to version 2.0.0, this container uses the ACME v2 servers (production &
 
 _NB: During a certificate renewal, the server (and authentication) used for the certificate generation will be reused, independently of the `LETSENCRYPT_ACME_V1` environment variable value. If you want to change the server used for a particular certificate, you will need first to revoke it by removing the relevant entry from `domains.txt` file before recreating it._
 
+### Specifying the renewal schedule
+
+By default the certificate regeneration process is run twice a day. This can be customized by setting the environment variable `CRON_TIME_STRING (default: "12 01,13 * * *")` to a cron time string. Be sure to also set the correct timezone using the environment variable `TZ (default: UTC)`.
+
 ### Activating staging ACME servers
 
 During development it is not advised to generate certificates against production ACME servers, as one could reach easily the weekly limit of Let's Encrypt and could not generate certificates for a certain period of time. Staging ACME servers do not have this limit. To use them, set the environment variable `LETSENCRYPT_STAGING (default: false)` to `true`.

--- a/files/crontab
+++ b/files/crontab
@@ -1,1 +1,0 @@
-12 01,13 * * * /scripts/renew.sh

--- a/files/run.sh
+++ b/files/run.sh
@@ -9,6 +9,7 @@ find /etc/letsencrypt/live /etc/letsencrypt/archive -type f -exec chmod "$CERTS_
 chown -R $CERTS_USER_OWNER:$CERTS_GROUP_OWNER /etc/letsencrypt/live /etc/letsencrypt/archive
 
 # Load crontab
+echo "$CRON_TIME_STRING /scripts/renew.sh" > /etc/crontab
 crontab /etc/crontab
 
 # Update TLDs


### PR DESCRIPTION
The certificate renewal process may trigger an autorestart of the container. I wanted to do this during the night when the services are not being used instead of potentially in the middle of the day. I have made the cron times customisable and added timezone support so the renewal script can be run whenever the user wants.