### PR TITLE
Add arm32v7 dockerfile for greate compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/python:3.7-alpine3.10
+FROM python:3.7-alpine3.10
 LABEL maintainer="Adrien Ferrand <ferrand.ad@gmail.com>"
 
 # Scripts in /scripts are required to be in the PATH to run properly as certbot's hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine3.10
+FROM arm32v7/python:3.7-alpine3.10
 LABEL maintainer="Adrien Ferrand <ferrand.ad@gmail.com>"
 
 # Scripts in /scripts are required to be in the PATH to run properly as certbot's hooks

--- a/Dockerfile-armh
+++ b/Dockerfile-armh
@@ -1,0 +1,65 @@
+FROM arm32v7/python:3.7-alpine3.10
+LABEL maintainer="Adrien Ferrand <ferrand.ad@gmail.com>"
+
+# Scripts in /scripts are required to be in the PATH to run properly as certbot's hooks
+ENV PATH /scripts:$PATH
+
+# Versioning
+ENV LEXICON_VERSION 3.3.1
+ENV CERTBOT_VERSION 0.36.0
+
+# Install dependencies, certbot, lexicon, prepare for first start and clean
+RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ openssl docker ethtool tzdata bash \
+ && apk --no-cache --update --virtual build-dependencies add libffi-dev libxml2-dev libxslt-dev openssl-dev build-base linux-headers \
+ && pip install --no-cache-dir "certbot==$CERTBOT_VERSION" \
+ && pip install --no-cache-dir "dns-lexicon[full]==$LEXICON_VERSION" \
+ && pip install --no-cache-dir circus \
+ && mkdir -p /var/lib/letsencrypt/hooks \
+ && mkdir -p /etc/circus.d \
+ && apk del build-dependencies
+
+# Let's Encrypt configuration
+ENV LETSENCRYPT_STAGING=false \
+    LETSENCRYPT_USER_MAIL=noreply@example.com \
+    LETSENCRYPT_ACME_V1=false \
+    LETSENCRYPT_SKIP_REGISTER=false
+
+# Lexicon configuration
+ENV LEXICON_OPTIONS="" \
+    LEXICON_PROVIDER=cloudflare \
+    LEXICON_PROVIDER_OPTIONS=""
+
+# Container specific configuration
+ENV TZ=UTC \
+    CRON_TIME_STRING="12 01,13 * * *" \
+    PFX_EXPORT=false \
+    PFX_EXPORT_PASSPHRASE="" \
+    CERTS_DIRS_MODE=0750 \
+    CERTS_FILES_MODE=0640 \
+    CERTS_USER_OWNER=root \
+    CERTS_GROUP_OWNER=root \
+    DEPLOY_HOOK=""
+
+# Container in cluster configuration (Swarm, Kubernetes ...)
+ENV DOCKER_CLUSTER_PROVIDER none
+
+# Copy scripts
+COPY files/run.sh \
+     files/watch-domains.sh \
+     files/autorestart-containers.sh \
+     files/autocmd-containers.sh \
+     files/deploy-hook.sh \
+     files/renew.sh /scripts/
+
+COPY files/authenticator.sh \
+     files/cleanup.sh /var/lib/letsencrypt/hooks/
+
+# Copy configuration files
+COPY files/circus.ini /etc/circus.ini
+COPY files/letsencrypt-dns.ini /etc/circus.d/letsencrypt-dns.ini
+
+RUN chmod +x /scripts/*
+
+VOLUME ["/etc/letsencrypt"]
+
+CMD ["/scripts/run.sh"]


### PR DESCRIPTION
I wanted to use this one on raspberry pi but it wouldn't run due to it being a x64 container, so I made a dockerfile with arm32v7/python base as image which should work just as well.
I've not updated the documentation on how to use this version because i don't know much about markdown and didn't want to mess with your readme.

You would run it like this:
```
docker build -t letsencrypt-dns -f Dockerfile-armh https://github.com/adferrand/docker-letsencrypt-dns
docker run -d <options> letsencrypt-dns
```