### PR TITLE
Added creation of domains.conf in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apk --no-cache --update add rsyslog git libffi libxml2 libxslt libstdc++ ope
  && pip install --no-cache-dir "certbot==$CERTBOT_VERSION" \
  && pip install --no-cache-dir "dns-lexicon[full]==$LEXICON_VERSION" \
  && pip install --no-cache-dir circus \
+ && mkdir -p /var/letsencrypt \
+ && touch /var/letsencrypt/domains.conf \
  && mkdir -p /var/lib/letsencrypt/hooks \
  && mkdir -p /etc/circus.d \
  && apk del build-dependencies

--- a/compose/.env
+++ b/compose/.env
@@ -15,6 +15,9 @@ PROVIDER=cloudflare
 # Provider options
 PROVIDER_OPTIONS=--auth-username=my_cloudflare_email --auth-token=my_cloudflare_global_api_key
 
+# DNS replication delay
+SLEEP_TIME=30
+
 # Certificate directory mode
 DIRS_MODE=0750
 

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -7,12 +7,13 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/domains.conf:/etc/letsencrypt/domains.conf"
-      - "$ROOT/certs/:/etc/letsencrypt"
+      - "$ROOT/:/etc/letsencrypt"
     environment:
       - VERSION=latest
       - "LETSENCRYPT_USER_MAIL=$EMAIL"
       - "LEXICON_PROVIDER=$PROVIDER"
       - "LEXICON_PROVIDER_OPTIONS=$PROVIDER_OPTIONS"
+      - "LEXICON_SLEEP_TIME=$SLEEP_TIME"
       - "CERTS_DIRS_MODE=$DIRS_MODE"
       - "CERTS_FILES_MODE=$FILES_MODE"
     restart: always


### PR DESCRIPTION
This PR contains:

* Those, who ran docker image before creation of mounting folders (as me), firstly will run into error:
![image](https://user-images.githubusercontent.com/13115270/63218092-88490580-c142-11e9-902d-a6cdf6bbfa46.png)
And then, when they copy their file and delete directory, will see: `/etc/letsencrypt/domains.conf\\" caused \\"not a directory\\"\""`
This problem described here: https://stackoverflow.com/a/47099098/8537739
To prevent this behavior we can add creation of `domains.conf` into Dockerfile.
* For docker-compose template I found confusing to create `certs` directory in $ROOT, because there is duplication of `domains.conf`. 
* Added `LEXICON_SLEEP_TIME` to docker-compose template because it is important setting.
* Made small improvements to README.md.